### PR TITLE
Changed stylus version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "enb stylus techs",
   "dependencies": {
     "vow": "0.4.8",
-    "stylus": "0.47.1",
+    "stylus": "~0.50.0",
     "autoprefixer": "~3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "enb stylus techs",
   "dependencies": {
     "vow": "0.4.8",
-    "stylus": "~0.50.0",
+    "stylus": "0.50.0",
     "autoprefixer": "~3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changed stylus version to `~0.50.0` with fix https://github.com/LearnBoost/stylus/pull/1778.
See https://github.com/enb-make/enb-stylus/issues/21.