### PR TITLE
Fix sourcemap.inline handling;

### DIFF
--- a/techs/css-stylus.js
+++ b/techs/css-stylus.js
@@ -137,8 +137,8 @@ module.exports = require('enb/lib/build-flow').create()
 
             if (this._sourcemap) {
                 opts.map = {
-                    prev: sourcemap,
-                    inline: this._sourcemap.inline
+                    prev: JSON.stringify(sourcemap),
+                    inline: !!this._sourcemap.inline
                 };
             }
 


### PR DESCRIPTION
Fix sourcemap.inline handling;
Pass sourcemap from stylus as a string to avoid false postcss error (when built css is empty);